### PR TITLE
Fix error that caused requests not to be made

### DIFF
--- a/app/javascript/packs/api/baseApi.js
+++ b/app/javascript/packs/api/baseApi.js
@@ -4,6 +4,7 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 const baseApi = createApi({
   baseQuery: fetchBaseQuery({ baseUrl: '/api' }),
   endpoints: () => ({}),
+  refetchOnMountOrArgChange: true,
 });
 
 export default baseApi;


### PR DESCRIPTION
## Description

Currently, when trying to make a request already done a few minutes ago, the request does not execute, due to caching made by rtk query.

This pull request aims to fix that.

## Requirements

None.

## Additional changes

None.
